### PR TITLE
feat: Add exception to handle API errors on signout

### DIFF
--- a/gotrue/_async/gotrue_client.py
+++ b/gotrue/_async/gotrue_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from functools import partial
 from json import loads
 from time import time
@@ -484,15 +485,12 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         There is no way to revoke a user's access token jwt until it expires.
         It is recommended to set a shorter expiry on the jwt for this reason.
         """
-        try:
+        with suppress(AuthApiError):
             session = await self.get_session()
             access_token = session.access_token if session else None
             if access_token:
                 await self.admin.sign_out(access_token)
-        except AuthApiError:
-            pass
-        except Exception:
-            raise
+
         await self._remove_session()
         self._notify_all_subscribers("SIGNED_OUT", None)
 

--- a/gotrue/_sync/gotrue_client.py
+++ b/gotrue/_sync/gotrue_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from functools import partial
 from json import loads
 from time import time
@@ -482,15 +483,12 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         There is no way to revoke a user's access token jwt until it expires.
         It is recommended to set a shorter expiry on the jwt for this reason.
         """
-        try:
+        with suppress(AuthApiError):
             session = self.get_session()
             access_token = session.access_token if session else None
             if access_token:
                 self.admin.sign_out(access_token)
-        except AuthApiError:
-            pass
-        except Exception:
-            raise
+
         self._remove_session()
         self._notify_all_subscribers("SIGNED_OUT", None)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Better exception handling on signout

## What is the current behavior?

Currently if you try to sign out after a user has been deleted an API error stating `User is not found` is raised.

## What is the new behavior?

If you try to sign out after a user has been deleted no API error stating `User is not found` is raised, but other types of exception can still be raised.

## Additional context

Add any other context or screenshots.
