### PR TITLE
add error codes

### DIFF
--- a/supabase_auth/errors.py
+++ b/supabase_auth/errors.py
@@ -16,19 +16,22 @@ class AuthApiErrorDict(TypedDict):
     name: str
     message: str
     status: int
+    code: str
 
 
 class AuthApiError(AuthError):
-    def __init__(self, message: str, status: int) -> None:
+    def __init__(self, message: str, status: int, code: str) -> None:
         AuthError.__init__(self, message)
         self.name = "AuthApiError"
         self.status = status
+        self.code = code
 
     def to_dict(self) -> AuthApiErrorDict:
         return {
             "name": self.name,
             "message": self.message,
             "status": self.status,
+            "code": self.code,
         }
 
 

--- a/supabase_auth/helpers.py
+++ b/supabase_auth/helpers.py
@@ -114,6 +114,10 @@ def get_error_message(error: Any) -> str:
     return next((error[prop] for prop in props if filter(prop)), str(error))
 
 
+def get_error_code(error: Any) -> str:
+    return error.get("error_code", None) if isinstance(error, dict) else None
+
+
 def looks_like_http_status_error(exception: Exception) -> bool:
     return isinstance(exception, HTTPStatusError)
 
@@ -129,7 +133,11 @@ def handle_exception(exception: Exception) -> AuthError:
                 get_error_message(error), error.response.status_code
             )
         json = error.response.json()
-        return AuthApiError(get_error_message(json), error.response.status_code or 500)
+        return AuthApiError(
+            get_error_message(json),
+            error.response.status_code or 500,
+            get_error_code(json),
+        )
     except Exception as e:
         return AuthUnknownError(get_error_message(error), e)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for error codes. All `AuthError` descendants will now have a `code` property which will encode (when present and supported by the server) the reason why the error occurred.

## What is the current behavior?

No error codes in AuthError

## What is the new behavior?

Error codes in AuthError

## Additional context

Add any other context or screenshots.
