### PR TITLE
Add update user jwt

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -585,18 +585,21 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
                 return None
         return await self._request("GET", "user", jwt=jwt, xform=parse_user_response)
 
-    async def update_user(self, attributes: UserAttributes) -> UserResponse:
+    async def update_user(self, attributes: UserAttributes, jwt: Union[str, None] = None) -> UserResponse:
         """
         Updates user data, if there is a logged in user.
         """
-        session = await self.get_session()
-        if not session:
-            raise AuthSessionMissingError()
+        if not jwt:
+            session = await self.get_session()
+            if session:
+                jwt = session.access_token
+            else:
+                raise AuthSessionMissingError()
         response = await self._request(
             "PUT",
             "user",
             body=attributes,
-            jwt=session.access_token,
+            jwt=jwt,
             xform=parse_user_response,
         )
         session.user = response.user

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -579,7 +579,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
                 return None
         return self._request("GET", "user", jwt=jwt, xform=parse_user_response)
 
-    def update_user(self, attributes: UserAttributes) -> UserResponse:
+    def update_user(self, attributes: UserAttributes, jwt: Union[str, None] = None) -> UserResponse:
         """
         Updates user data, if there is a logged in user.
         """

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -583,14 +583,17 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         """
         Updates user data, if there is a logged in user.
         """
-        session = self.get_session()
-        if not session:
-            raise AuthSessionMissingError()
+        if not jwt:
+            session = self.get_session()
+            if session:
+                jwt = session.access_token
+            else:
+                raise AuthSessionMissingError()
         response = self._request(
             "PUT",
             "user",
             body=attributes,
-            jwt=session.access_token,
+            jwt=jwt,
             xform=parse_user_response,
         )
         session.user = response.user


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds jwt parameter to both synchronous and asynchronous update_user functions. 

## What is the current behavior?

```
session = self.get_session()
if not session:
    raise AuthSessionMissingError()
```
This is how the access token was taken for the request before, I just added a jwt parameter to get the access token straight away. 

Please link any relevant issues here.

#563 

## What is the new behavior?

```
if not jwt:
  session = self.get_session()
  if session:
      jwt = session.access_token
  else:
      raise AuthSessionMissingError()
```
This is the check that I added. 
Obviously there is awaits for the asynchronous one. 