### PR TITLE
Allow session to be valid without refresh token provided

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -604,7 +604,9 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         self._notify_all_subscribers("USER_UPDATED", session)
         return response
 
-    async def set_session(self, access_token: str, refresh_token: str) -> AuthResponse:
+    async def set_session(
+        self, access_token: str, refresh_token: Union[str, None] = None
+    ) -> AuthResponse:
         """
         Sets the session data from the current session. If the current session
         is expired, `set_session` will take care of refreshing it to obtain a
@@ -1008,8 +1010,6 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         if not data:
             return None
         if not data.get("access_token"):
-            return None
-        if not data.get("refresh_token"):
             return None
         if not data.get("expires_at"):
             return None

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -598,7 +598,9 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         self._notify_all_subscribers("USER_UPDATED", session)
         return response
 
-    def set_session(self, access_token: str, refresh_token: str) -> AuthResponse:
+    def set_session(
+        self, access_token: str, refresh_token: Union[str, None] = None
+    ) -> AuthResponse:
         """
         Sets the session data from the current session. If the current session
         is expired, `set_session` will take care of refreshing it to obtain a
@@ -1000,8 +1002,6 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         if not data:
             return None
         if not data.get("access_token"):
-            return None
-        if not data.get("refresh_token"):
             return None
         if not data.get("expires_at"):
             return None

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -135,7 +135,7 @@ class Session(BaseModel):
     documentation for information on how to obtain the provider refresh token.
     """
     access_token: str
-    refresh_token: str
+    refresh_token: Union[str, None] = None
     expires_in: int
     """
     The number of seconds until the token expires (since it was issued).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Now if provide only access token to the `set_session` method, client will be authenticated and configured, but consequent calls to `supabase.auth.get_sesion` or `supabase.auth.get_user` will return `None` which is confusing.

```py
from supabase import Client, create_client
supabase = create_client(settings.supabase_url, settings.supabase_anon_key)

supabase.auth.set_session(access_token=result.data["access_token"], refresh_token=result.data["refresh_token"])
# => AuthResponse(user=User(id='75672178-…))

supabase.auth.get_sessionO()
=> None
```

This is because current session is deleted from internal storage if its refresh key is absent (and most surprisingly this deletion happen from the `get_session` method). See [here](https://github.com/supabase/auth-py/blob/abfe2e5a10d19de4dc47a2f97596cd3effc83bae/supabase_auth/_async/gotrue_client.py#L554-L556) for details.

But it is pretty convenient to create short sessions from access token only, and let some upstream app to manage these keys by itstelf.

**Workaround**:

Provide some dummy non-empty refresh token, e.g.

```py
supabase.auth.set_session(access_token=token, refresh_token="foobar")
```

## What is the new behavior?

`supabase.auth.get_session` and `supabase.auth.get_user` returns session and user accordingly.

See:

```rm
supabase.auth.set_session(new_auth.session.access_token,new_auth.session.refresh_token)
# => AuthResponse(user=User(…) session=Session(…)
```
