### PR TITLE
fix: update password reset method name to match js lib

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -711,11 +711,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         self._state_change_emitters[unique_id] = subscription
         return subscription
 
-    async def reset_password_email(
-        self,
-        email: str,
-        options: Options = {},
-    ) -> None:
+    async def reset_password_for_email(self, email: str, options: Options = {}) -> None:
         """
         Sends a password reset request to an email address.
         """
@@ -730,6 +726,16 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             },
             redirect_to=options.get("redirect_to"),
         )
+
+    async def reset_password_email(
+        self,
+        email: str,
+        options: Options = {},
+    ) -> None:
+        """
+        Sends a password reset request to an email address.
+        """
+        await self.reset_password_for_email(email, options)
 
     # MFA methods
 

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -703,11 +703,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         self._state_change_emitters[unique_id] = subscription
         return subscription
 
-    def reset_password_email(
-        self,
-        email: str,
-        options: Options = {},
-    ) -> None:
+    def reset_password_for_email(self, email: str, options: Options = {}) -> None:
         """
         Sends a password reset request to an email address.
         """
@@ -722,6 +718,16 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             },
             redirect_to=options.get("redirect_to"),
         )
+
+    def reset_password_email(
+        self,
+        email: str,
+        options: Options = {},
+    ) -> None:
+        """
+        Sends a password reset request to an email address.
+        """
+        self.reset_password_for_email(email, options)
 
     # MFA methods
 

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -84,7 +84,7 @@ class AMREntry(BaseModel):
 
 class Options(TypedDict):
     redirect_to: NotRequired[str]
-    data: NotRequired[Any]
+    captcha_token: NotRequired[str]
 
 
 class AuthResponse(BaseModel):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update method name to match the JS client library.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
