### PR TITLE
feat: add resend method

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -525,16 +525,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         credentials: ResendCredentials,
     ) -> AuthOtpResponse:
         """
-        Log in a user using magiclink or a one-time password (OTP).
-
-        If the `{{ .ConfirmationURL }}` variable is specified in
-        the email template, a magiclink will be sent.
-
-        If the `{{ .Token }}` variable is specified in the email
-        template, an OTP will be sent.
-
-        If you're using phone sign-ins, only an OTP will be sent.
-        You won't be able to send a magiclink for phone sign-ins.
+        Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
         """
         email = credentials.get("email")
         phone = credentials.get("phone")
@@ -555,7 +546,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             )
 
         body.update({"email": email} if email else {"phone": phone})
-        print(f"BODY: {body}")
+
         return await self._request(
             "POST",
             "resend",

--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -61,6 +61,7 @@ from ..types import (
     OAuthResponse,
     Options,
     Provider,
+    ResendCredentials,
     Session,
     SignInAnonymouslyCredentials,
     SignInWithIdTokenCredentials,
@@ -517,6 +518,50 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             )
         raise AuthInvalidCredentialsError(
             "You must provide either an email or phone number"
+        )
+
+    async def resend(
+        self,
+        credentials: ResendCredentials,
+    ) -> AuthOtpResponse:
+        """
+        Log in a user using magiclink or a one-time password (OTP).
+
+        If the `{{ .ConfirmationURL }}` variable is specified in
+        the email template, a magiclink will be sent.
+
+        If the `{{ .Token }}` variable is specified in the email
+        template, an OTP will be sent.
+
+        If you're using phone sign-ins, only an OTP will be sent.
+        You won't be able to send a magiclink for phone sign-ins.
+        """
+        email = credentials.get("email")
+        phone = credentials.get("phone")
+        type = credentials.get("type")
+        options = credentials.get("options", {})
+        email_redirect_to = options.get("email_redirect_to")
+        captcha_token = options.get("captcha_token")
+        body = {
+            "type": type,
+            "gotrue_meta_security": {
+                "captcha_token": captcha_token,
+            },
+        }
+
+        if email is None and phone is None:
+            raise AuthInvalidCredentialsError(
+                "You must provide either an email or phone number"
+            )
+
+        body.update({"email": email} if email else {"phone": phone})
+        print(f"BODY: {body}")
+        return await self._request(
+            "POST",
+            "resend",
+            body=body,
+            redirect_to=email_redirect_to if email else None,
+            xform=parse_auth_otp_response,
         )
 
     async def verify_otp(self, params: VerifyOtpParams) -> AuthResponse:

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -519,16 +519,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         credentials: ResendCredentials,
     ) -> AuthOtpResponse:
         """
-        Log in a user using magiclink or a one-time password (OTP).
-
-        If the `{{ .ConfirmationURL }}` variable is specified in
-        the email template, a magiclink will be sent.
-
-        If the `{{ .Token }}` variable is specified in the email
-        template, an OTP will be sent.
-
-        If you're using phone sign-ins, only an OTP will be sent.
-        You won't be able to send a magiclink for phone sign-ins.
+        Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
         """
         email = credentials.get("email")
         phone = credentials.get("phone")
@@ -549,7 +540,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             )
 
         body.update({"email": email} if email else {"phone": phone})
-        print(f"BODY: {body}")
+
         return self._request(
             "POST",
             "resend",

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -61,6 +61,7 @@ from ..types import (
     OAuthResponse,
     Options,
     Provider,
+    ResendCredentials,
     Session,
     SignInAnonymouslyCredentials,
     SignInWithIdTokenCredentials,
@@ -511,6 +512,50 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             )
         raise AuthInvalidCredentialsError(
             "You must provide either an email or phone number"
+        )
+
+    def resend(
+        self,
+        credentials: ResendCredentials,
+    ) -> AuthOtpResponse:
+        """
+        Log in a user using magiclink or a one-time password (OTP).
+
+        If the `{{ .ConfirmationURL }}` variable is specified in
+        the email template, a magiclink will be sent.
+
+        If the `{{ .Token }}` variable is specified in the email
+        template, an OTP will be sent.
+
+        If you're using phone sign-ins, only an OTP will be sent.
+        You won't be able to send a magiclink for phone sign-ins.
+        """
+        email = credentials.get("email")
+        phone = credentials.get("phone")
+        type = credentials.get("type")
+        options = credentials.get("options", {})
+        email_redirect_to = options.get("email_redirect_to")
+        captcha_token = options.get("captcha_token")
+        body = {
+            "type": type,
+            "gotrue_meta_security": {
+                "captcha_token": captcha_token,
+            },
+        }
+
+        if email is None and phone is None:
+            raise AuthInvalidCredentialsError(
+                "You must provide either an email or phone number"
+            )
+
+        body.update({"email": email} if email else {"phone": phone})
+        print(f"BODY: {body}")
+        return self._request(
+            "POST",
+            "resend",
+            body=body,
+            redirect_to=email_redirect_to if email else None,
+            xform=parse_auth_otp_response,
         )
 
     def verify_otp(self, params: VerifyOtpParams) -> AuthResponse:

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -376,6 +376,30 @@ SignInWithPasswordlessCredentials = Union[
 ]
 
 
+class ResendEmailCredentialsOptions(TypedDict):
+    email_redirect_to: NotRequired[str]
+    captcha_token: NotRequired[str]
+
+
+class ResendEmailCredentials(TypedDict):
+    type: Literal["signup", "email_change"]
+    email: str
+    options: NotRequired[ResendEmailCredentialsOptions]
+
+
+class ResendPhoneCredentialsOptions(TypedDict):
+    captcha_token: NotRequired[str]
+
+
+class ResendPhoneCredentials(TypedDict):
+    type: Literal["sms", "phone_change"]
+    phone: str
+    options: NotRequired[ResendPhoneCredentialsOptions]
+
+
+ResendCredentials = Union[ResendEmailCredentials, ResendPhoneCredentials]
+
+
 class SignInWithOAuthCredentialsOptions(TypedDict):
     redirect_to: NotRequired[str]
     scopes: NotRequired[str]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add resend method for emails to be resent for an existing signup confirmation email, email change email, SMS OTP or phone change OTP.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
