### PR TITLE
fix: update invite user by email option type

### DIFF
--- a/supabase_auth/_async/gotrue_admin_api.py
+++ b/supabase_auth/_async/gotrue_admin_api.py
@@ -13,7 +13,7 @@ from ..types import (
     AuthMFAAdminListFactorsResponse,
     GenerateLinkParams,
     GenerateLinkResponse,
-    Options,
+    InviteUserByEmailOptions,
     SignOutScope,
     User,
     UserResponse,
@@ -57,7 +57,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
     async def invite_user_by_email(
         self,
         email: str,
-        options: Options = {},
+        options: InviteUserByEmailOptions = {},
     ) -> UserResponse:
         """
         Sends an invite link to an email address.

--- a/supabase_auth/_sync/gotrue_admin_api.py
+++ b/supabase_auth/_sync/gotrue_admin_api.py
@@ -13,7 +13,7 @@ from ..types import (
     AuthMFAAdminListFactorsResponse,
     GenerateLinkParams,
     GenerateLinkResponse,
-    Options,
+    InviteUserByEmailOptions,
     SignOutScope,
     User,
     UserResponse,
@@ -57,7 +57,7 @@ class SyncGoTrueAdminAPI(SyncGoTrueBaseAPI):
     def invite_user_by_email(
         self,
         email: str,
-        options: Options = {},
+        options: InviteUserByEmailOptions = {},
     ) -> UserResponse:
         """
         Sends an invite link to an email address.

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -87,6 +87,11 @@ class Options(TypedDict):
     captcha_token: NotRequired[str]
 
 
+class InviteUserByEmailOptions(TypedDict):
+    redirect_to: NotRequired[str]
+    data: NotRequired[Any]
+
+
 class AuthResponse(BaseModel):
     user: Union[User, None] = None
     session: Union[Session, None] = None


### PR DESCRIPTION
## What kind of change does this PR introduce?

I made a change in a previous PR to fix the Options type https://github.com/supabase/auth-py/pull/584, but didn't realise it was being used by the `invite_user_by_email` options type.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
