### PR TITLE
Cleanout

### DIFF
--- a/supabase_auth/_async/__init__.py
+++ b/supabase_auth/_async/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/supabase_auth/_async/gotrue_admin_api.py
+++ b/supabase_auth/_async/gotrue_admin_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from functools import partial
 from typing import Dict, List, Union
 

--- a/supabase_auth/_async/gotrue_base_api.py
+++ b/supabase_auth/_async/gotrue_base_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Callable, Dict, TypeVar, Union, overload
 
 from httpx import Response

--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from contextlib import suppress
 from functools import partial
 from json import loads

--- a/supabase_auth/_async/storage.py
+++ b/supabase_auth/_async/storage.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
 

--- a/supabase_auth/_sync/__init__.py
+++ b/supabase_auth/_sync/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/supabase_auth/_sync/api.py
+++ b/supabase_auth/_sync/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import parse_obj_as

--- a/supabase_auth/_sync/client.py
+++ b/supabase_auth/_sync/client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from functools import partial
 from json import dumps, loads
 from threading import Timer

--- a/supabase_auth/_sync/gotrue_admin_api.py
+++ b/supabase_auth/_sync/gotrue_admin_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from functools import partial
 from typing import Dict, List, Union
 

--- a/supabase_auth/_sync/gotrue_base_api.py
+++ b/supabase_auth/_sync/gotrue_base_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Callable, Dict, TypeVar, Union, overload
 
 from httpx import Response

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from contextlib import suppress
 from functools import partial
 from json import loads

--- a/supabase_auth/_sync/storage.py
+++ b/supabase_auth/_sync/storage.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
 

--- a/supabase_auth/constants.py
+++ b/supabase_auth/constants.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import datetime
 from typing import Dict
 

--- a/supabase_auth/helpers.py
+++ b/supabase_auth/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import hashlib
 import re

--- a/supabase_auth/http_clients.py
+++ b/supabase_auth/http_clients.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from httpx import AsyncClient  # noqa: F401
 from httpx import Client as BaseClient
 

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import datetime
 from time import time
 from typing import Any, Callable, Dict, List, Union


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Cleanout future imports `from __future__ import annotations` no longer needed for Python >= `3.9.0`.
