### PR TITLE
fix: mfa challenge channel field not required

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -822,7 +822,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
         return await self._request(
             "POST",
             f"factors/{params.get('factor_id')}/challenge",
-            body={"channel": params["channel"]},
+            body={"channel": params.get("channel")},
             jwt=session.access_token,
             xform=partial(model_validate, AuthMFAChallengeResponse),
         )

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -814,7 +814,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         return self._request(
             "POST",
             f"factors/{params.get('factor_id')}/challenge",
-            body={"channel": params["channel"]},
+            body={"channel": params.get("channel")},
             jwt=session.access_token,
             xform=partial(model_validate, AuthMFAChallengeResponse),
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Requires channel property

## What is the new behavior?

Does not require the channel property

## Additional context

https://github.com/supabase/supabase-py/issues/921
