### PR TITLE
Fix _save_session's default behavior

### DIFF
--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -1011,8 +1011,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
         )
 
     def _save_session(self, session: Session) -> None:
-        if not self._persist_session:
-            self._in_memory_session = session
+        self._in_memory_session = session
         expire_at = session.expires_at
         if expire_at:
             time_now = round(time())


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR fixes a bug where `client.set_session(access_token, refresh_token)` doesn't actually update the in-memory session. This can be easily seen by creating a client and calling `set_session` followed by `get_session`. The `set_session` call appears to work and returns a valid response, but the subsequent `get_session` call returns None, revealing that the session was never set properly.

As a workaround, you can set `persist_session` to False in the client options, but this shouldn't be necessary.

## What is the current behavior?
`set_session` does not properly update the in-memory session when the `persist_session` option is True (default).

This issue was closed although the bug still exists https://github.com/supabase/auth-py/issues/324

## What is the new behavior?
`set_session` works.