### PR TITLE
fix: set timer to be use daemon thread

### DIFF
--- a/supabase_auth/timer.py
+++ b/supabase_auth/timer.py
@@ -28,6 +28,7 @@ class Timer:
             self._task.add_done_callback(cleanup)
         else:
             self._timer = _Timer(self._milliseconds / 1000, self._function)
+            self._timer.daemon = True
             self._timer.start()
 
     def cancel(self) -> None:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If any sign in method is called a timer kicks off to handle token refresh, however if you should exit the program the timer gets disrupted and doesn't stop correctly because of the thread its running on.

## What is the new behavior?

Timer stops correctly because it now makes use of a daemon thread.

## Additional context

https://github.com/supabase/supabase-py/issues/494
https://github.com/supabase/supabase-py/issues/844
https://github.com/supabase/supabase-py/issues/451