### PR TITLE
feat: adds banned_until to user type

### DIFF
--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -222,7 +222,7 @@ class User(BaseModel):
     identities: Optional[List[UserIdentity]] = None
     is_anonymous: bool = False
     factors: Optional[List[Factor]] = None
-
+    banned_until: Optional[datetime] = None
 
 class UserAttributes(TypedDict):
     email: NotRequired[str]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the banned_until to the User response so we can have access to it inside of our applications.

## What is the current behavior?

Does not currently return this data

## What is the new behavior?

Returns the banned_until datetime to the response when getting a user like: supabase.auth.admin.get_user_by_id(uuid)
