### PR TITLE
fix: sign_out not clearing session when exception raised

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -721,12 +721,10 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
 
     async def sign_out(self, options: SignOutOptions = {"scope": "global"}) -> None:
         """
-        Inside a browser context, `sign_out` will remove the logged in user from the
-        browser session and log them out - removing all items from localstorage and
-        then trigger a `"SIGNED_OUT"` event.
+        `sign_out` will remove the logged in user from the
+        current session and log them out - removing all items from storage and then trigger a `"SIGNED_OUT"` event.
 
-        For server-side management, you can revoke all refresh tokens for a user by
-        passing a user's JWT through to `api.sign_out`.
+        For advanced use cases, you can revoke all refresh tokens for a user by passing a user's JWT through to `admin.sign_out`.
 
         There is no way to revoke a user's access token jwt until it expires.
         It is recommended to set a shorter expiry on the jwt for this reason.
@@ -737,9 +735,9 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             if access_token:
                 await self.admin.sign_out(access_token, options["scope"])
 
-            if options["scope"] != "others":
-                await self._remove_session()
-                self._notify_all_subscribers("SIGNED_OUT", None)
+        if options["scope"] != "others":
+            await self._remove_session()
+            self._notify_all_subscribers("SIGNED_OUT", None)
 
     def on_auth_state_change(
         self,

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -717,12 +717,10 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
 
     def sign_out(self, options: SignOutOptions = {"scope": "global"}) -> None:
         """
-        Inside a browser context, `sign_out` will remove the logged in user from the
-        browser session and log them out - removing all items from localstorage and
-        then trigger a `"SIGNED_OUT"` event.
+        `sign_out` will remove the logged in user from the
+        current session and log them out - removing all items from storage and then trigger a `"SIGNED_OUT"` event.
 
-        For server-side management, you can revoke all refresh tokens for a user by
-        passing a user's JWT through to `api.sign_out`.
+        For advanced use cases, you can revoke all refresh tokens for a user by passing a user's JWT through to `admin.sign_out`.
 
         There is no way to revoke a user's access token jwt until it expires.
         It is recommended to set a shorter expiry on the jwt for this reason.
@@ -733,9 +731,9 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             if access_token:
                 self.admin.sign_out(access_token, options["scope"])
 
-            if options["scope"] != "others":
-                self._remove_session()
-                self._notify_all_subscribers("SIGNED_OUT", None)
+        if options["scope"] != "others":
+            self._remove_session()
+            self._notify_all_subscribers("SIGNED_OUT", None)
 
     def on_auth_state_change(
         self,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an exception is raised during sign_out the session isn't cleared from the storage even though user is signed out

## What is the new behavior?

If an exception is raised during sign_out the session is cleared from the storage

## Additional context

Add any other context or screenshots.
