### PR TITLE
fix: move redirect_to into metadata for SSO authentication

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -370,8 +370,8 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },
+                    "redirect_to": redirect_to,
                 },
-                redirect_to=redirect_to,
                 xform=parse_sso_response,
             )
         if provider_id:
@@ -384,8 +384,8 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },
+                    "redirect_to": redirect_to,
                 },
-                redirect_to=redirect_to,
                 xform=parse_sso_response,
             )
         raise AuthInvalidCredentialsError(

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -370,8 +370,8 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },
+                    "redirect_to": redirect_to,
                 },
-                redirect_to=redirect_to,
                 xform=parse_sso_response,
             )
         if provider_id:
@@ -384,8 +384,8 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
                     "gotrue_meta_security": {
                         "captcha_token": captcha_token,
                     },
+                    "redirect_to": redirect_to,
                 },
-                redirect_to=redirect_to,
                 xform=parse_sso_response,
             )
         raise AuthInvalidCredentialsError(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Corrects the handling of `redirect_to` parameter in SSO authentication.
Closes #670

## What is the current behavior?

In the GoTrue client's `sign_in_with_sso` method, the `redirect_to` parameter is being passed as a separate parameter to the `_request` method instead of being included in the request body. This can cause issues with SSO redirects not working as expected.

Current implementation:
```python
return self._request(
    "POST",
    "sso",
    body={
        "domain": domain,
        "skip_http_redirect": skip_http_redirect,
        "gotrue_meta_security": {
            "captcha_token": "",
        },
    },
    redirect_to=redirect_to,  # Incorrectly placed here
    xform=parse_sso_response,
)
```

Relates to issue: [#670](https://github.com/supabase/auth-py/issues/670)

## What is the current behavior?
The redirect_to parameter is now correctly included in the request body:

```python
return self._request(
    "POST",
    "sso",
    body={
        "domain": domain,
        "skip_http_redirect": skip_http_redirect,
        "gotrue_meta_security": {
            "captcha_token": "",
        },
        "redirect_to": redirect_to,  # Correctly placed in body
    },
    xform=parse_sso_response,
)
```

This change ensures that SSO redirects are handled properly according to the GoTrue API specifications.

## Additional context
- This fix affects both domain-based and provider-based SSO authentication flows
- The change aligns the Python implementation with the expected API behavior
- No breaking changes are introduced