### PR TITLE
fix: validate uuid on admin methods and fix wrong factor in delete_factor method

### DIFF
--- a/supabase_auth/_async/gotrue_admin_api.py
+++ b/supabase_auth/_async/gotrue_admin_api.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from functools import partial
 from typing import Dict, List, Optional
 
-from ..helpers import model_validate, parse_link_response, parse_user_response
+from ..helpers import (
+    is_valid_uuid,
+    model_validate,
+    parse_link_response,
+    parse_user_response,
+)
 from ..http_clients import AsyncClient
 from ..types import (
     AdminUserAttributes,
@@ -131,6 +136,8 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         This function should only be called on a server.
         Never expose your `service_role` key in the browser.
         """
+        self._validate_uuid(uid)
+
         return await self._request(
             "GET",
             f"admin/users/{uid}",
@@ -148,6 +155,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         This function should only be called on a server.
         Never expose your `service_role` key in the browser.
         """
+        self._validate_uuid(uid)
         return await self._request(
             "PUT",
             f"admin/users/{uid}",
@@ -162,6 +170,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         This function should only be called on a server.
         Never expose your `service_role` key in the browser.
         """
+        self._validate_uuid(id)
         body = {"should_soft_delete": should_soft_delete}
         return await self._request("DELETE", f"admin/users/{id}", body=body)
 
@@ -169,6 +178,7 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         self,
         params: AuthMFAAdminListFactorsParams,
     ) -> AuthMFAAdminListFactorsResponse:
+        self._validate_uuid(params.get("user_id"))
         return await self._request(
             "GET",
             f"admin/users/{params.get('user_id')}/factors",
@@ -179,8 +189,14 @@ class AsyncGoTrueAdminAPI(AsyncGoTrueBaseAPI):
         self,
         params: AuthMFAAdminDeleteFactorParams,
     ) -> AuthMFAAdminDeleteFactorResponse:
+        self._validate_uuid(params.get("user_id"))
+        self._validate_uuid(params.get("id"))
         return await self._request(
             "DELETE",
-            f"admin/users/{params.get('user_id')}/factors/{params.get('factor_id')}",
+            f"admin/users/{params.get('user_id')}/factors/{params.get('id')}",
             xform=partial(model_validate, AuthMFAAdminDeleteFactorResponse),
         )
+
+    def _validate_uuid(self, id: str) -> None:
+        if not is_valid_uuid(id):
+            raise ValueError(f"Invalid id, '{id}' is not a valid uuid")

--- a/supabase_auth/helpers.py
+++ b/supabase_auth/helpers.py
@@ -5,6 +5,7 @@ import hashlib
 import re
 import secrets
 import string
+import uuid
 from base64 import urlsafe_b64decode
 from datetime import datetime
 from json import loads
@@ -317,3 +318,11 @@ def validate_exp(exp: int) -> None:
     time_now = datetime.now().timestamp()
     if exp <= time_now:
         raise AuthInvalidJwtError("JWT has expired")
+
+
+def is_valid_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False

--- a/tests/_async/test_gotrue_admin_api.py
+++ b/tests/_async/test_gotrue_admin_api.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from supabase_auth.errors import (
@@ -588,3 +590,51 @@ async def test_weak_phone_password_error():
         )
     except (AuthWeakPasswordError, AuthApiError) as e:
         assert e.to_dict()
+
+
+async def test_get_user_by_id_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        await service_role_api_client().get_user_by_id("invalid_id")
+
+
+async def test_update_user_by_id_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        await service_role_api_client().update_user_by_id(
+            "invalid_id", {"email": "test@test.com"}
+        )
+
+
+async def test_delete_user_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        await service_role_api_client().delete_user("invalid_id")
+
+
+async def test_list_factors_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        await service_role_api_client()._list_factors({"user_id": "invalid_id"})
+
+
+async def test_delete_factor_invalid_id_raises_error():
+    # invalid user id
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        await service_role_api_client()._delete_factor(
+            {"user_id": "invalid_id", "id": "invalid_id"}
+        )
+
+    # valid user id, invalid factor id
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        await service_role_api_client()._delete_factor(
+            {"user_id": str(uuid.uuid4()), "id": "invalid_id"}
+        )

--- a/tests/_sync/test_gotrue_admin_api.py
+++ b/tests/_sync/test_gotrue_admin_api.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from supabase_auth.errors import (
@@ -590,3 +592,51 @@ def test_weak_phone_password_error():
         )
     except (AuthWeakPasswordError, AuthApiError) as e:
         assert e.to_dict()
+
+
+def test_get_user_by_id_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        service_role_api_client().get_user_by_id("invalid_id")
+
+
+def test_update_user_by_id_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        service_role_api_client().update_user_by_id(
+            "invalid_id", {"email": "test@test.com"}
+        )
+
+
+def test_delete_user_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        service_role_api_client().delete_user("invalid_id")
+
+
+def test_list_factors_invalid_id_raises_error():
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        service_role_api_client()._list_factors({"user_id": "invalid_id"})
+
+
+def test_delete_factor_invalid_id_raises_error():
+    # invalid user id
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        service_role_api_client()._delete_factor(
+            {"user_id": "invalid_id", "id": "invalid_id"}
+        )
+
+    # valid user id, invalid factor id
+    with pytest.raises(
+        ValueError, match=r"Invalid id, 'invalid_id' is not a valid uuid"
+    ):
+        service_role_api_client()._delete_factor(
+            {"user_id": str(uuid.uuid4()), "id": "invalid_id"}
+        )


### PR DESCRIPTION
This pull request introduces UUID validation for user-related operations in both the asynchronous and synchronous versions of the `gotrue_admin_api` module. It ensures that invalid UUIDs are caught early, preventing unnecessary API calls. Additionally, new tests have been added to verify this behavior.

### UUID Validation Enhancements:

* Added a new helper function `is_valid_uuid` in `supabase_auth/helpers.py` to validate UUIDs.
* Introduced a `_validate_uuid` method in both `supabase_auth/_async/gotrue_admin_api.py` and `supabase_auth/_sync/gotrue_admin_api.py` to validate UUIDs before making API requests. [[1]](diffhunk://#diff-fc39cc968a0c0a1c8048ea263364bddcdab0f8bb2efe29ce99e6f6a4e801f640R192-R202) [[2]](diffhunk://#diff-95a69ea357efbbd4306ec7fea3f233c4703da9c11182d33faf79a35df21c384dR192-R202)
* Updated all relevant methods (`get_user_by_id`, `update_user_by_id`, `delete_user`, `_list_factors`, `_delete_factor`) in `gotrue_admin_api` to call `_validate_uuid` for input validation. [[1]](diffhunk://#diff-fc39cc968a0c0a1c8048ea263364bddcdab0f8bb2efe29ce99e6f6a4e801f640R139-R140) [[2]](diffhunk://#diff-fc39cc968a0c0a1c8048ea263364bddcdab0f8bb2efe29ce99e6f6a4e801f640R158) [[3]](diffhunk://#diff-fc39cc968a0c0a1c8048ea263364bddcdab0f8bb2efe29ce99e6f6a4e801f640R173-R181) [[4]](diffhunk://#diff-fc39cc968a0c0a1c8048ea263364bddcdab0f8bb2efe29ce99e6f6a4e801f640R192-R202) [[5]](diffhunk://#diff-95a69ea357efbbd4306ec7fea3f233c4703da9c11182d33faf79a35df21c384dR139-R140) [[6]](diffhunk://#diff-95a69ea357efbbd4306ec7fea3f233c4703da9c11182d33faf79a35df21c384dR158) [[7]](diffhunk://#diff-95a69ea357efbbd4306ec7fea3f233c4703da9c11182d33faf79a35df21c384dR173-R181) [[8]](diffhunk://#diff-95a69ea357efbbd4306ec7fea3f233c4703da9c11182d33faf79a35df21c384dR192-R202)

### Test Coverage:

* Added tests in `tests/_async/test_gotrue_admin_api.py` to verify that invalid UUIDs raise `ValueError` in all relevant methods.
* Added equivalent tests in `tests/_sync/test_gotrue_admin_api.py` for the synchronous API.

### Other Changes:

* Updated imports in `supabase_auth/_async/gotrue_admin_api.py` and `supabase_auth/_sync/gotrue_admin_api.py` to include `is_valid_uuid`. [[1]](diffhunk://#diff-fc39cc968a0c0a1c8048ea263364bddcdab0f8bb2efe29ce99e6f6a4e801f640L6-R11) [[2]](diffhunk://#diff-95a69ea357efbbd4306ec7fea3f233c4703da9c11182d33faf79a35df21c384dL6-R11)
* Added `uuid` import in `supabase_auth/helpers.py` to support UUID validation.