### PR TITLE
fix: add missing email_redirect_to option

### DIFF
--- a/supabase_auth/_async/gotrue_client.py
+++ b/supabase_auth/_async/gotrue_client.py
@@ -79,6 +79,7 @@ from ..types import (
     SignOutOptions,
     SignUpWithPasswordCredentials,
     Subscription,
+    UpdateUserOptions,
     UserAttributes,
     UserIdentity,
     UserResponse,
@@ -647,7 +648,9 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
                 return None
         return await self._request("GET", "user", jwt=jwt, xform=parse_user_response)
 
-    async def update_user(self, attributes: UserAttributes) -> UserResponse:
+    async def update_user(
+        self, attributes: UserAttributes, options: UpdateUserOptions = {}
+    ) -> UserResponse:
         """
         Updates user data, if there is a logged in user.
         """
@@ -658,6 +661,7 @@ class AsyncGoTrueClient(AsyncGoTrueBaseAPI):
             "PUT",
             "user",
             body=attributes,
+            redirect_to=options.get("email_redirect_to"),
             jwt=session.access_token,
             xform=parse_user_response,
         )

--- a/supabase_auth/_sync/gotrue_client.py
+++ b/supabase_auth/_sync/gotrue_client.py
@@ -79,6 +79,7 @@ from ..types import (
     SignOutOptions,
     SignUpWithPasswordCredentials,
     Subscription,
+    UpdateUserOptions,
     UserAttributes,
     UserIdentity,
     UserResponse,
@@ -645,7 +646,9 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
                 return None
         return self._request("GET", "user", jwt=jwt, xform=parse_user_response)
 
-    def update_user(self, attributes: UserAttributes) -> UserResponse:
+    def update_user(
+        self, attributes: UserAttributes, options: UpdateUserOptions = {}
+    ) -> UserResponse:
         """
         Updates user data, if there is a logged in user.
         """
@@ -656,6 +659,7 @@ class SyncGoTrueClient(SyncGoTrueBaseAPI):
             "PUT",
             "user",
             body=attributes,
+            redirect_to=options.get("email_redirect_to"),
             jwt=session.access_token,
             xform=parse_user_response,
         )

--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -87,6 +87,10 @@ class Options(TypedDict):
     captcha_token: NotRequired[str]
 
 
+class UpdateUserOptions(TypedDict):
+    email_redirect_to: NotRequired[str]
+
+
 class InviteUserByEmailOptions(TypedDict):
     redirect_to: NotRequired[str]
     data: NotRequired[Any]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`.update_user` method is missing the `email_redirect_to` property.

## What is the new behavior?

`.update_user` method now has the `email_redirect_to` property.

## Additional context

I will add a PR to update the reference docs on the Supabase website in relation to this too.

In relation to #727 