### PR TITLE
fix: add missing nonce to the update_user method

### DIFF
--- a/supabase_auth/types.py
+++ b/supabase_auth/types.py
@@ -233,6 +233,7 @@ class UserAttributes(TypedDict):
     phone: NotRequired[str]
     password: NotRequired[str]
     data: NotRequired[Any]
+    nonce: NotRequired[str]
 
 
 class AdminUserAttributes(UserAttributes, TypedDict):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add missing `nonce` to the update_user method

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
